### PR TITLE
Currently, the output doesn't get formatted as defined by the formatter

### DIFF
--- a/lib/log4r-gelf/gelf_outputter.rb
+++ b/lib/log4r-gelf/gelf_outputter.rb
@@ -33,7 +33,7 @@ module Log4r
       def canonical_log(logevent)
         level = LEVELS_MAP[Log4r::LNAMES[logevent.level]]
 
-        msg = "#{logevent.fullname}: #{logevent.data.to_s}"
+        msg = format(logevent)
 
         if logevent.data.respond_to?(:backtrace)
           trace = logevent.data.backtrace

--- a/lib/log4r-gelf/version.rb
+++ b/lib/log4r-gelf/version.rb
@@ -1,5 +1,5 @@
 module Log4r
   module Gelf
-    VERSION = "0.5.0"
+    VERSION = "0.5.0.1"
   end
 end


### PR DESCRIPTION
Currently, the output doesn't get formatted as defined by the pattern formatter. It is much more flexible for the users to be able to define a formatting pattern in the config files. 

The output produced by    msg = "#{logevent.fullname}: #{logevent.data.to_s}" can be achieved by defining a formatter as below

```
  formatter: 
    pattern: "%C: %m "
    type: PatternFormatter
```
