### PR TITLE
Non synched notify

### DIFF
--- a/lib/log4r-gelf/gelf_outputter.rb
+++ b/lib/log4r-gelf/gelf_outputter.rb
@@ -93,11 +93,9 @@ module Log4r
           end
         end
         
-        synch do
-          opts[:short_message] = format(logevent) unless opts[:short_message]
+        opts[:short_message] = format(logevent) unless opts[:short_message]
   
-          @notifier.notify!(opts)
-        end
+        @notifier.notify!(opts)
       rescue => err
         puts "Graylog2 logger. Could not send message: " + err.message
         puts err.backtrace.join("\n") if err.backtrace

--- a/log4r-gelf.gemspec
+++ b/log4r-gelf.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("log4r", '~> 1.1.10')
-  s.add_dependency("gelf", '~> 1.3')
+  s.add_dependency("gelf", '>= 1.4.0')
   
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')


### PR DESCRIPTION
gelf 1.4 and up is threadsafe, so there's really no need to synch the notify call.  Removing the synch block makes a pretty substantial performance difference in our case
